### PR TITLE
fix(collector): serialize collector cycles across instances with a lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ follows [SemVer](https://semver.org/) — under `0.x`, a MINOR bump signals
 
 ## [Unreleased]
 
+### Fixed
+
+- A multi-monitor setup could fire the same desktop notification twice
+  for one real transition — Quickshell mounts the whole widget (Timer
+  included) once per screen, so each monitor ran its own independent
+  collector cycle with no coordination between them. Only one instance
+  now runs a given cycle; the rest skip it cleanly.
+
 ## [0.1.4] - 2026-09-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ still running when the next one would start is skipped, not stacked, so
 a slow cycle (cold SSH connections, a project with many branches) never
 piles up overlapping runs.
 
+On a multi-monitor setup, Quickshell mounts the widget — Timer included —
+once per screen, so more than one of these cycles can genuinely be
+scheduled at the same time. A lock (`Owlook::CollectorLock`) ensures only
+one of them actually runs a given cycle; the rest skip it immediately,
+since whichever one wins already covers the same shared state file.
+
 This means polling only happens while the Omarchy shell itself is
 running — restarting it (`omarchy restart shell`, a theme change, a
 crash) pauses updates until it comes back, same as any other bar widget.

--- a/collector/bin/owlook-collector
+++ b/collector/bin/owlook-collector
@@ -34,6 +34,15 @@ STATE_PATH = File.join(Owlook::RuntimeDir.resolve, "owlook.json")
 # $XDG_RUNTIME_DIR — resolve's own STATE_PATH is fine losing that because
 # it's rebuilt every cycle regardless.
 GITHUB_CACHE_PATH = File.join(Owlook::RuntimeDir.resolve_cache_dir, "github_cache.json")
+# Ephemeral like STATE_PATH — a lock only means anything for cycles
+# racing within the same boot, never across one. See CollectorLock's own
+# comment for the real bug this exists to prevent: Quickshell mounts this
+# whole widget (Timer included) once per screen, so a 2-monitor setup
+# means 2 independent 30s timers, each spawning their own instance of
+# this script — confirmed live to fire the same desktop notification
+# twice for one real transition, both instances racing to read the same
+# "before" state with zero coordination.
+LOCK_PATH = File.join(Owlook::RuntimeDir.resolve, "owlook.lock")
 
 # A settings toggle or a config.yml edit (see BarWidget.qml's
 # startCollectorCycle) kills a cycle already in progress instead of
@@ -65,33 +74,45 @@ def log(message)
   $stderr.flush
 end
 
-github_cache = Owlook::GithubCache.new(GITHUB_CACHE_PATH)
-rate_limit_guard = Owlook::RateLimitGuard.new
-client = Owlook::GithubClient.new(
-  token: Owlook::GithubClient.resolve_token,
-  cache: github_cache,
-  rate_limit_guard: rate_limit_guard
-)
-config_loader = -> { Owlook::Config.load(CONFIG_PATH) }
+# Everything that touches shared state — reading STATE_PATH/
+# GITHUB_CACHE_PATH through to writing them back out — happens inside
+# the lock, not just the polling in between: a second instance reading
+# either file mid-cycle would be reading something this cycle hasn't
+# finished updating yet.
+ran = Owlook::CollectorLock.new(LOCK_PATH).run_exclusively do
+  github_cache = Owlook::GithubCache.new(GITHUB_CACHE_PATH)
+  rate_limit_guard = Owlook::RateLimitGuard.new
+  client = Owlook::GithubClient.new(
+    token: Owlook::GithubClient.resolve_token,
+    cache: github_cache,
+    rate_limit_guard: rate_limit_guard
+  )
+  config_loader = -> { Owlook::Config.load(CONFIG_PATH) }
 
-collector = Owlook::Collector.new(
-  config_loader: config_loader,
-  store: Owlook::Store.load(STATE_PATH),
-  writer: Owlook::StateWriter.new(STATE_PATH),
-  github_source: Owlook::Sources::GitHub.new(client: client),
-  logger: method(:log)
-)
+  collector = Owlook::Collector.new(
+    config_loader: config_loader,
+    store: Owlook::Store.load(STATE_PATH),
+    writer: Owlook::StateWriter.new(STATE_PATH),
+    github_source: Owlook::Sources::GitHub.new(client: client),
+    logger: method(:log)
+  )
 
-log("cycle starting: watching #{CONFIG_PATH} (#{config_loader.call.projects.size} project(s)) -> #{STATE_PATH}")
-collector.poll_ci_once
-collector.poll_queues_once
-# Unconditional, even with zero projects configured — see
-# Collector#flush_state's own comment for why that case specifically
-# needs this (poll_ci_once/poll_queues_once never touch the state file at
-# all when there's nothing to poll).
-collector.flush_state
-# Unconditional, same as flush_state above — even a cycle that hit the
-# rate-limit guard partway through should keep whatever real ETags it
-# did collect before that point, not discard them.
-github_cache.save
-log("cycle finished")
+  log("cycle starting: watching #{CONFIG_PATH} (#{config_loader.call.projects.size} project(s)) -> #{STATE_PATH}")
+  collector.poll_ci_once
+  collector.poll_queues_once
+  # Unconditional, even with zero projects configured — see
+  # Collector#flush_state's own comment for why that case specifically
+  # needs this (poll_ci_once/poll_queues_once never touch the state file
+  # at all when there's nothing to poll).
+  collector.flush_state
+  # Unconditional, same as flush_state above — even a cycle that hit the
+  # rate-limit guard partway through should keep whatever real ETags it
+  # did collect before that point, not discard them.
+  github_cache.save
+  log("cycle finished")
+end
+
+# Not an error — the other holder is another instance of this exact
+# script (see LOCK_PATH's own comment), already doing this cycle's work
+# from the same shared state. Nothing left for this one to contribute.
+log("another collector cycle is already running elsewhere — skipping this cycle") unless ran

--- a/collector/lib/owlook.rb
+++ b/collector/lib/owlook.rb
@@ -21,6 +21,7 @@ require_relative "owlook/widget_settings"
 require_relative "owlook/notifier"
 require_relative "owlook/store"
 require_relative "owlook/state_writer"
+require_relative "owlook/collector_lock"
 require_relative "owlook/collector"
 
 module Owlook

--- a/collector/lib/owlook/collector_lock.rb
+++ b/collector/lib/owlook/collector_lock.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Owlook
+  # Ensures only one collector cycle runs at a time across every instance
+  # of the widget on this machine — not just within a single one.
+  #
+  # BarWidget.qml's own Timer+Process already stops a single instance from
+  # overlapping itself (see its `if (!collectorProcess.running)` guard),
+  # but that guard is per-instance, in-memory, and Quickshell instantiates
+  # the whole widget (Timer included) once per screen: Bar.qml renders via
+  # `Variants { model: Quickshell.screens }`, and its own ModuleList
+  # comment says the identical thing about mounting a module twice — "two
+  # of every timer and fetch behind them". A 2-monitor setup means 2
+  # independent 30s timers, each spawning its own bin/owlook-collector,
+  # both reading/writing the same shared state file with no coordination
+  # at all. Confirmed live: this is exactly what caused a real user's
+  # desktop to show the same transition notified twice — both instances
+  # raced to read the same "before" state and both called Notifier.
+  #
+  # flock, not a PID or "does this file exist" lock: those need their own
+  # staleness logic (what if the process that made the file died?) — a
+  # flock is tied to the holding process's own open file description and
+  # is released by the kernel the instant that process exits, for any
+  # reason, crash included. Nothing here can ever leave a stale lock
+  # behind for a later cycle to get stuck on.
+  class CollectorLock
+    def initialize(path)
+      @path = path
+    end
+
+    # Runs the block and returns true only if this process is the sole
+    # holder of the lock right now. Returns false, without running the
+    # block, if another instance already holds it — that instance is
+    # already doing this exact cycle's work from the same shared state,
+    # so there is nothing for this one to contribute by also doing it.
+    def run_exclusively
+      File.open(@path, File::RDWR | File::CREAT | File::NOFOLLOW, 0o600) do |file|
+        return false unless file.flock(File::LOCK_EX | File::LOCK_NB)
+
+        yield
+        true
+      end
+    rescue Errno::ELOOP
+      # Another local user planted a symlink at this exact path. Unlike
+      # GithubCache/StateWriter, there's no content here to trust or
+      # distrust — the only thing at stake is whether two instances might
+      # race this one cycle, which is exactly today's pre-this-fix
+      # behavior. Running without the lock this once is a safer response
+      # than either following the symlink or refusing to poll at all.
+      yield
+      true
+    end
+  end
+end

--- a/collector/test/owlook/collector_lock_test.rb
+++ b/collector/test/owlook/collector_lock_test.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+class Owlook::CollectorLockTest < Minitest::Test
+  def test_runs_the_block_and_returns_true_when_uncontended
+    with_path do |path|
+      lock = Owlook::CollectorLock.new(path)
+      ran = false
+
+      result = lock.run_exclusively { ran = true }
+
+      assert result
+      assert ran
+    end
+  end
+
+  # flock is tied to the open file description, not the process or the
+  # path — a second File.open on the same path, in the same process, is
+  # a distinct holder exactly like a second real collector process would
+  # be. This is the standard way to test flock contention without
+  # actually forking.
+  def test_does_not_run_the_block_while_another_holder_has_the_lock
+    with_path do |path|
+      # Held open across the whole example on purpose, not the block
+      # form — closing it is exactly what would release the lock this
+      # test needs held.
+      holder = File.open(path, File::RDWR | File::CREAT, 0o600) # rubocop:disable Style/FileOpen
+      holder.flock(File::LOCK_EX)
+
+      lock = Owlook::CollectorLock.new(path)
+      ran = false
+
+      result = lock.run_exclusively { ran = true }
+
+      refute result
+      refute ran
+    ensure
+      holder&.flock(File::LOCK_UN)
+      holder&.close
+    end
+  end
+
+  # The real scenario this exists for: two independent bin/owlook-collector
+  # processes (one per monitor, see the class's own comment), not two
+  # File handles in one process. Forks a real child that holds the lock
+  # while the parent tries to run its own cycle — proving contention
+  # actually works across process boundaries, not just within one.
+  def test_a_real_second_process_holding_the_lock_blocks_this_one
+    with_path do |path|
+      reader, writer = IO.pipe
+      child_pid = fork do
+        reader.close
+        child_lock = Owlook::CollectorLock.new(path)
+        child_lock.run_exclusively do
+          writer.write("locked")
+          writer.close
+          sleep 5 # held well past the parent's own attempt below
+        end
+      end
+      writer.close
+      reader.read(6) # blocks until the child actually holds the lock
+      reader.close
+
+      lock = Owlook::CollectorLock.new(path)
+      ran = false
+
+      result = lock.run_exclusively { ran = true }
+
+      refute result
+      refute ran
+    ensure
+      Process.kill("TERM", child_pid) if child_pid
+      Process.wait(child_pid) if child_pid
+    end
+  end
+
+  # The whole point of using flock over a PID/existence-based lock file:
+  # nothing has to notice the holder is gone or clean anything up — the
+  # kernel releases it the instant the holding process's file descriptor
+  # closes, crash included (simulated here with SIGKILL, not a clean
+  # exit).
+  def test_the_lock_is_available_again_immediately_after_the_holder_is_killed
+    with_path do |path|
+      child_pid = fork do
+        child_lock = Owlook::CollectorLock.new(path)
+        child_lock.run_exclusively { sleep 30 }
+      end
+      sleep 0.2 # let the child actually acquire it first
+      Process.kill("KILL", child_pid)
+      Process.wait(child_pid)
+
+      lock = Owlook::CollectorLock.new(path)
+      ran = false
+
+      result = lock.run_exclusively { ran = true }
+
+      assert result
+      assert ran
+    end
+  end
+
+  # Same attack class StateWriter/GithubCache guard against — a symlink
+  # planted at this exact path. There's no content to trust or distrust
+  # here, only whether two instances might race one cycle, which is
+  # exactly today's pre-fix behavior: proceeding without the lock is a
+  # safer response than following the symlink or refusing to poll.
+  def test_a_symlinked_lock_path_still_runs_the_block_instead_of_raising
+    with_path do |path|
+      victim = "#{path}.victim"
+      File.write(victim, "untouched")
+      File.symlink(victim, path)
+
+      lock = Owlook::CollectorLock.new(path)
+      ran = false
+
+      result = lock.run_exclusively { ran = true }
+
+      assert result
+      assert ran
+      assert_equal "untouched", File.read(victim)
+    end
+  end
+
+  def test_creates_the_lock_file_with_0600_not_a_world_or_group_readable_mode
+    with_path do |path|
+      lock = Owlook::CollectorLock.new(path)
+
+      lock.run_exclusively { nil }
+
+      assert_equal 0o600, File.stat(path).mode & 0o777
+    end
+  end
+
+  private
+
+  def with_path
+    Dir.mktmpdir do |dir|
+      yield File.join(dir, "owlook.lock")
+    end
+  end
+end


### PR DESCRIPTION
## Problem

A user with two monitors reported the same desktop notification firing twice for one real event (confirmed with them: same message, not two different destinations like prod/stg).

Root cause: Quickshell mounts `BarWidget.qml` — Timer included — once per screen (`Bar.qml` renders via `Variants { model: Quickshell.screens }`, and its own `ModuleList` comment already documents this exact class of bug: "mounts every center module twice — two of every timer and fetch behind them"). A 2-monitor setup means 2 independent 30s timers, each spawning its own `bin/owlook-collector` process, with zero coordination between them. Both read/write the same shared state file; both independently detect the same transition and each call the real `Notifier`.

Confirmed live, end-to-end, using the real `Collector`/`Notifier`/`omarchy-notification-send` code path with a controlled/forced transition: two collector processes racing on the same seeded state produced two real desktop notifications for one event. There is no other trigger for `bin/owlook-collector` in the codebase (no systemd unit, no cron) — this only happens with more than one live `BarWidget.qml` instance (multi-monitor, or multiple concurrent graphical sessions of the same user).

## Fix

A non-blocking `flock`, wrapped in a small `Owlook::CollectorLock` class, around the entire cycle in `bin/owlook-collector`. Only the instance that acquires the lock does the real work (poll, write state, notify); every other instance skips that tick cleanly and does nothing, since the winning instance already covers the same shared state.

`flock` specifically, not a PID/existence-based lock file: it's tied to the holding process's own open file description and is released by the kernel the instant that process exits — normal exit, SIGTERM, or a hard crash. No stale-lock cleanup logic needed, and nothing can get stuck waiting on a lock whose owner is gone.

Re-verified live after the fix: two concurrent real `bin/owlook-collector` invocations against the same (isolated) state — one runs the cycle and notifies once, the other logs "another collector cycle is already running elsewhere — skipping this cycle" and does nothing.

## Verification

- 211 tests, 0 failures (6 new for `CollectorLock`, including a real forked child process holding the lock, and a `SIGKILL` case proving the lock is available again immediately with no stale state).
- RuboCop clean across the whole repo.
- Live end-to-end reproduction, both before (2 real notifications for 1 event) and after (1 real notification for 1 event) the fix, using the real collector/notifier code path.